### PR TITLE
Fix timer death when revive

### DIFF
--- a/source/server/commands/Admin.commands.ts
+++ b/source/server/commands/Admin.commands.ts
@@ -282,6 +282,10 @@ RAGERP.commands.add({
 
         targetPlayer.character.setStoreData(player, "isDead", false);
         targetPlayer.setVariable("isDead", false);
+        
+        targetPlayer.setVariable("deathTime", 30);
+        targetPlayer.character.setStoreData(player, "deathTime", 30);
+        
         targetPlayer.stopScreenEffect("DeathFailMPIn");
         targetPlayer.stopAnimation();
 


### PR DESCRIPTION
When the player died, and was revived and died again, the timer remained as it was before. Now this way it is reset to the way it was at the beginning.